### PR TITLE
Add more defaults (used by mingw on windows)

### DIFF
--- a/sqlite-ffi.lisp
+++ b/sqlite-ffi.lisp
@@ -37,7 +37,7 @@
 (define-foreign-library sqlite3-lib
   (:darwin (:default "libsqlite3"))
   (:unix (:or "libsqlite3.so.0" "libsqlite3.so"))
-  (t (:or (:default "libsqlite3") (:default "sqlite3"))))
+  (t (:or (:default "libsqlite3") (:default "libsqlite3-0") (:default "sqlite3") (:default "sqlite3-0"))))
 
 (use-foreign-library sqlite3-lib)
 


### PR DESCRIPTION
The library name used by mingw on windows is `libsqlite3-0.dll`.