### PR TITLE
Add function to activate/deactivate extension loading

### DIFF
--- a/sqlite-ffi.lisp
+++ b/sqlite-ffi.lisp
@@ -30,7 +30,8 @@
            :sqlite3-bind-blob
            :destructor-transient
            :destructor-static
-           :sqlite3-last-insert-rowid))
+           :sqlite3-last-insert-rowid
+           :sqlite3-enable-load-extension))
 
 (in-package :sqlite-ffi)
 
@@ -198,3 +199,7 @@
 
 (defcfun sqlite3-last-insert-rowid :int64
   (db p-sqlite3))
+
+(defcfun sqlite3-enable-load-extension :int
+  (db p-sqlite3)
+  (onoff :int))

--- a/sqlite.lisp
+++ b/sqlite.lisp
@@ -29,6 +29,7 @@
            :execute-non-query/named
            :execute-one-row-m-v
            :last-insert-rowid
+           :enable-load-extension
            :with-transaction
            :with-open-database))
 
@@ -438,6 +439,10 @@ See BIND-PARAMETER for the list of supported parameter types."
 (defun last-insert-rowid (db)
   "Returns the auto-generated ID of the last inserted row on the database connection DB."
   (sqlite-ffi:sqlite3-last-insert-rowid (handle db)))
+
+(defun enable-load-extension (db enable)
+  "Enable extension loading, or disable it if ENABLE is NIL."
+  (sqlite-ffi:sqlite3-enable-load-extension (handle db) (if enable 1 0)))
 
 (defmacro with-transaction (db &body body)
   "Wraps the BODY inside the transaction."


### PR DESCRIPTION
This gives the ability to load extension modules (e.g. mod_spatialite) using:
 ``` sql
SELECT load_extension('/path/to/some/module')
```
