### PR TITLE
Added name for native windows dll (Windows 10)

### DIFF
--- a/sqlite-ffi.lisp
+++ b/sqlite-ffi.lisp
@@ -37,7 +37,7 @@
 (define-foreign-library sqlite3-lib
   (:darwin (:default "libsqlite3"))
   (:unix (:or "libsqlite3.so.0" "libsqlite3.so"))
-  (t (:or (:default "libsqlite3") (:default "sqlite3"))))
+  (t (:or (:default "libsqlite3") (:default "sqlite3") (:default "winsqlite3"))))
 
 (use-foreign-library sqlite3-lib)
 


### PR DESCRIPTION
Normally the winsqlite3 dll file will be present by default on Windows 10 (and possibly 11), so this change allows this library to compile without any third party installation of sqlite3.