### PR TITLE
Fix bind-param of displaced vectors

### DIFF
--- a/sqlite.asd
+++ b/sqlite.asd
@@ -13,9 +13,11 @@
                (:file "cache")
                (:file "sqlite" :depends-on ("sqlite-ffi" "cache")))
 
-  :depends-on (:iterate :cffi)
+  :depends-on (:iterate :cffi :babel)
 
   :in-order-to ((test-op (load-op sqlite-tests))))
+
+(register-system-packages "babel" '(#:babel-encodings))
 
 (defmethod perform ((o asdf:test-op) (c (eql (find-system :sqlite))))
   (funcall (intern "RUN-ALL-SQLITE-TESTS" :sqlite-tests)))

--- a/sqlite.lisp
+++ b/sqlite.lisp
@@ -386,9 +386,9 @@ Supported types:
                         (double-float (sqlite-ffi:sqlite3-bind-double (handle statement) index value))
                         (real (sqlite-ffi:sqlite3-bind-double (handle statement) index (coerce value 'double-float)))
                         (string (sqlite-ffi:sqlite3-bind-text (handle statement) index value -1 (sqlite-ffi:destructor-transient)))
-                        ((vector (unsigned-byte 8)) (babel-encodings:with-checked-simple-vector ((value value) (start (nth-value 1 (array-displacement value))) (end (length value)))
+                        ((vector (unsigned-byte 8)) (babel-encodings:with-checked-simple-vector ((value value) (start 0) (end nil))
                                                       (cffi:with-pointer-to-vector-data (ptr value)
-                                                        (sqlite-ffi:sqlite3-bind-blob (handle statement) index (cffi:inc-pointer ptr start) (length value) (sqlite-ffi:destructor-transient)))))
+                                                        (sqlite-ffi:sqlite3-bind-blob (handle statement) index (cffi:inc-pointer ptr start) (- end start) (sqlite-ffi:destructor-transient)))))
                         (vector (cffi:with-foreign-object (array :unsigned-char (length value))
                                   (loop
                                      for i from 0 below (length value)

--- a/sqlite.lisp
+++ b/sqlite.lisp
@@ -386,8 +386,9 @@ Supported types:
                         (double-float (sqlite-ffi:sqlite3-bind-double (handle statement) index value))
                         (real (sqlite-ffi:sqlite3-bind-double (handle statement) index (coerce value 'double-float)))
                         (string (sqlite-ffi:sqlite3-bind-text (handle statement) index value -1 (sqlite-ffi:destructor-transient)))
-                        ((vector (unsigned-byte 8)) (cffi:with-pointer-to-vector-data (ptr value)
-                                                      (sqlite-ffi:sqlite3-bind-blob (handle statement) index ptr (length value) (sqlite-ffi:destructor-transient))))
+                        ((vector (unsigned-byte 8)) (babel-encodings:with-checked-simple-vector ((value value) (start (nth-value 1 (array-displacement value))) (end (length value)))
+                                                      (cffi:with-pointer-to-vector-data (ptr value)
+                                                        (sqlite-ffi:sqlite3-bind-blob (handle statement) index (cffi:inc-pointer ptr start) (length value) (sqlite-ffi:destructor-transient)))))
                         (vector (cffi:with-foreign-object (array :unsigned-char (length value))
                                   (loop
                                      for i from 0 below (length value)


### PR DESCRIPTION
When the underlying vector is displaced on another array, and potentially with a fill pointer below its capacity, we need to do some pointer arithmetic. We use babel to extract the underlying simple array because it's already a transitive dependency via cffi.

Without this patch, I have to copy non-simple vectors before inserting, which is wasteful.